### PR TITLE
Simulate counterfactuals

### DIFF
--- a/ehr2vec/common/setup.py
+++ b/ehr2vec/common/setup.py
@@ -19,7 +19,10 @@ def get_args(default_config_name, default_run_name=None):
     """Get command line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--config_path", type=str, default=join("configs", default_config_name), help="Configuration file, path relative to configs/" 
+        "--config_path",
+        type=str,
+        default=join("configs", default_config_name),
+        help="Configuration file, path relative to configs/",
     )
     parser.add_argument(
         "--run_name",
@@ -33,7 +36,7 @@ def get_args(default_config_name, default_run_name=None):
         args.config_path = join("configs", args.config_path)
     if not args.config_path.endswith(".yaml"):
         args.config_path += ".yaml"
-    
+
     return args
 
 

--- a/ehr2vec/common/setup.py
+++ b/ehr2vec/common/setup.py
@@ -19,7 +19,7 @@ def get_args(default_config_name, default_run_name=None):
     """Get command line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--config_path", type=str, default=join("configs", default_config_name)
+        "--config_path", type=str, default=join("configs", default_config_name), help="Configuration file, path relative to configs/" 
     )
     parser.add_argument(
         "--run_name",
@@ -31,6 +31,9 @@ def get_args(default_config_name, default_run_name=None):
     args = parser.parse_args()
     if not args.config_path.startswith("configs"):
         args.config_path = join("configs", args.config_path)
+    if not args.config_path.endswith(".yaml"):
+        args.config_path += ".yaml"
+    
     return args
 
 

--- a/ehr2vec/configs/finetune/finetune_simvastatin.yaml
+++ b/ehr2vec/configs/finetune/finetune_simvastatin.yaml
@@ -1,10 +1,10 @@
 env: local
 paths:
-  pretrain_model_path: "../outputs/pretraining/test"
+  pretrain_model_path: "outputs/example_pretraining/example"
   # model_path: "outputs/pretraining/behrt_test/finetune_TEST_OUTCOME_censored_10_hours_pre_TEST_OUTCOME_test"
   #checkpoint_epoch: 1
-  outcome: "../outputs/features500/outcomes/SIMVASTATIN/SIMVASTATIN.csv"
-  exposure: "../outputs/features500/outcomes/SIMVASTATIN/SIMVASTATIN.csv"
+  outcome: "outputs/example_features/outcomes/SIMVASTATIN/SIMVASTATIN.csv"
+  exposure: "outputs/example_features/outcomes/SIMVASTATIN/SIMVASTATIN.csv"
   #output_path: "outputs/finetuning"
   run_name: "test"
   #tokenized_dir:"tokenized"

--- a/ehr2vec/configs/outcome/outcomes_simvastatin.yaml
+++ b/ehr2vec/configs/outcome/outcomes_simvastatin.yaml
@@ -1,10 +1,10 @@
 env: local
 paths:
-  run_name: first
+  run_name: test
 outcomes_name: "SIMVASTATIN"
-features_dir: ../outputs/features500
+features_dir: outputs/example_features
 loader:
-  data_dir: ../data/formatted/synthea500
+  data_dir: example_data/synthea500
   concepts: [
     medication
   ]
@@ -13,7 +13,7 @@ loader:
 outcomes:
   SIMVASTATIN: 
     type: [CONCEPT]
-    match: [['312961']]
+    match: [['M312961']]
     match_how: contains
     case_sensitive: true
   

--- a/ehr2vec/configs/simulate_binary_outcome.yaml
+++ b/ehr2vec/configs/simulate_binary_outcome.yaml
@@ -1,8 +1,8 @@
 env: local
 paths:
-  model_path: "../outputs/pretraining/test/finetune_SIMVASTATIN_censored_1_hours_pre_SIMVASTATIN_followup_start_at_index_date_test"
+  model_path: "outputs/example_pretraining/example/finetune_SIMVASTATIN_censored_1_hours_pre_SIMVASTATIN_followup_start_at_index_date_test"
   run_name: simulate_binary_outcome
-  output: "../outputs/features500/outcomes/SIMVASTATIN_simulated_outcome"
+  output: "outputs/example_features/outcomes/SIMVASTATIN_simulated_outcome"
 
 simulation:
   _target_: ehr2vec.simulation.binary_outcome.tbehrt

--- a/ehr2vec/data_fixes/infer.py
+++ b/ehr2vec/data_fixes/infer.py
@@ -26,16 +26,12 @@ class Inferrer:
     def infer_admission_id(df: pd.DataFrame) -> pd.Series:
         """Infer admission IDs (NaNs between identical IDs are inferred)"""
         bf = df.sort_values("PID")
-        mask = bf["SEGMENT"].fillna(method="ffill") != bf["SEGMENT"].fillna(
-            method="bfill"
-        )  # Find NaNs between similar admission IDs
+        mask = bf["SEGMENT"].ffill() != bf["SEGMENT"].bfill()  # Find NaNs between similar admission IDs
         bf.loc[mask, "SEGMENT"] = bf.loc[mask, "SEGMENT"].map(lambda _: "unq_") + list(
             map(str, range(mask.sum()))
         )  # Assign unique IDs to non-inferred NaNs
 
-        return bf["SEGMENT"].fillna(
-            method="ffill"
-        )  # Assign neighbour IDs to inferred NaNs
+        return bf["SEGMENT"].ffill()  # Assign neighbour IDs to inferred NaNs
 
     # Infer timestamps (NaNs within identical admission IDs a related timestamp)
     @staticmethod
@@ -43,7 +39,7 @@ class Inferrer:
         df: pd.DataFrame, strategy="last"
     ) -> pd.Series:
         if strategy == "last":
-            return df.groupby("SEGMENT")["TIMESTAMP"].fillna(method="ffill")
+            return df.groupby("SEGMENT")["TIMESTAMP"].ffill()
 
         elif strategy == "first":
             return df.groupby("SEGMENT")["TIMESTAMP"].transform(

--- a/ehr2vec/data_fixes/infer.py
+++ b/ehr2vec/data_fixes/infer.py
@@ -26,7 +26,9 @@ class Inferrer:
     def infer_admission_id(df: pd.DataFrame) -> pd.Series:
         """Infer admission IDs (NaNs between identical IDs are inferred)"""
         bf = df.sort_values("PID")
-        mask = bf["SEGMENT"].ffill() != bf["SEGMENT"].bfill()  # Find NaNs between similar admission IDs
+        mask = (
+            bf["SEGMENT"].ffill() != bf["SEGMENT"].bfill()
+        )  # Find NaNs between similar admission IDs
         bf.loc[mask, "SEGMENT"] = bf.loc[mask, "SEGMENT"].map(lambda _: "unq_") + list(
             map(str, range(mask.sum()))
         )  # Assign unique IDs to non-inferred NaNs

--- a/ehr2vec/downstream_tasks/outcomes.py
+++ b/ehr2vec/downstream_tasks/outcomes.py
@@ -165,7 +165,7 @@ class OutcomeHandler:
         select_patient_group (optional): select only exposed or unexposed patients
         drop_pids_w_outcome_pre_followup (optional): remove patients with outcome before follow-up start
         n_hours_start_followup (optional): number of hours to start follow-up after exposure (looking for positive label)
-        survival: whether survival analysis data (T and E) should be returned.
+        time2event: whether survival analysis data (T and E) should be returned.
         end_of_time: dictionary with year, month, day, hour, minute, second for the end of data collection period.
         death_is_event: count death as event in survival analysis
         """

--- a/ehr2vec/main/simulate_outcome_binary.py
+++ b/ehr2vec/main/simulate_outcome_binary.py
@@ -33,9 +33,15 @@ def main(config_path: str) -> None:
     df_index_dates = load_index_dates(cfg.paths.model_path)
     df_merged = pd.merge(df_predictions, df_index_dates, on="pid")
 
-    binary_outcome = simulate_outcome(df_merged["proba"], df_merged["target"], cfg.simulation)
-    binary_outcome_exp = simulate_outcome(df_merged["proba"], np.ones(len(df_merged)), cfg.simulation)
-    binary_outcome_ctrl = simulate_outcome(df_merged["proba"], np.zeros(len(df_merged)), cfg.simulation)
+    binary_outcome = simulate_outcome(
+        df_merged["proba"], df_merged["target"], cfg.simulation
+    )
+    binary_outcome_exp = simulate_outcome(
+        df_merged["proba"], np.ones(len(df_merged)), cfg.simulation
+    )
+    binary_outcome_ctrl = simulate_outcome(
+        df_merged["proba"], np.zeros(len(df_merged)), cfg.simulation
+    )
 
     abspos_outcome = simulate_abspos_from_binary_outcome(
         binary_outcome,
@@ -46,7 +52,9 @@ def main(config_path: str) -> None:
     result_df = pd.DataFrame({"PID": df_merged["pid"], "TIMESTAMP": abspos_outcome})
     os.makedirs(cfg.paths.output, exist_ok=True)
     result_df.dropna().to_csv(join(cfg.paths.output, "SIMULATED.csv"), index=False)
-    counterfactual_df = pd.DataFrame({"PID": df_merged["pid"], "Y1":binary_outcome_exp, "Y0": binary_outcome_ctrl})
+    counterfactual_df = pd.DataFrame(
+        {"PID": df_merged["pid"], "Y1": binary_outcome_exp, "Y0": binary_outcome_ctrl}
+    )
     counterfactual_df.to_csv(join(cfg.paths.output, "COUNTERFACTUAL.csv"), index=False)
 
     if cfg.env == "azure":
@@ -62,8 +70,10 @@ def main(config_path: str) -> None:
         mount_context.stop()
     logger.info("Done")
 
+
 def simulate_outcome(proba, target, simulation_cfg):
     return get_function(simulation_cfg)(proba, target, **simulation_cfg.params)
+
 
 if __name__ == "__main__":
     main(config_path)

--- a/tests/test_data/test_batch.py
+++ b/tests/test_data/test_batch.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call, patch
 
 from ehr2vec.data.batch import Batches, BatchTokenize, Split
 from ehr2vec.data.tokenizer import EHRTokenizer
-from ehr2vec.tests.helpers import ConfigMock
+from tests.helpers import ConfigMock
 
 
 class TestBatches(unittest.TestCase):

--- a/tests/test_data/test_creators.py
+++ b/tests/test_data/test_creators.py
@@ -11,7 +11,7 @@ from ehr2vec.data.creators import (
     SegmentCreator,
 )
 from ehr2vec.data.utils import Utilities
-from ehr2vec.tests.helpers import ConfigMock
+from tests.helpers import ConfigMock
 
 
 class TestBaseCreator(unittest.TestCase):

--- a/tests/test_data/test_featuremaker.py
+++ b/tests/test_data/test_featuremaker.py
@@ -1,7 +1,7 @@
 import unittest
 import pandas as pd
 from ehr2vec.data.featuremaker import FeatureMaker
-from ehr2vec.tests.helpers import ConfigMock
+from tests.helpers import ConfigMock
 
 
 class TestFeatureMaker(unittest.TestCase):

--- a/tests/test_data/test_filter.py
+++ b/tests/test_data/test_filter.py
@@ -70,6 +70,7 @@ class TestPatientFilter(unittest.TestCase):
         self.data.vocabulary = {f"code{i}": i for i in range(2, 9)}
         self.data.vocabulary["BG_GENDER_Female"] = 0
         self.data.vocabulary["BG_GENDER_Male"] = 1
+        self.data.times2event = None
 
     @patch("torch.load")
     def test_exclude_pretrain_patients(self, mock_load):

--- a/tests/test_data/test_filter.py
+++ b/tests/test_data/test_filter.py
@@ -1,7 +1,7 @@
 import random
 import unittest
 from unittest.mock import Mock, patch
-from ehr2vec.tests.helpers import ConfigMock
+from tests.helpers import ConfigMock
 from ehr2vec.data.filter import CodeTypeFilter, PatientFilter
 
 

--- a/tests/test_data/test_tokenizer.py
+++ b/tests/test_data/test_tokenizer.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from ehr2vec.tests.helpers import ConfigMock
+from tests.helpers import ConfigMock
 from ehr2vec.data.tokenizer import EHRTokenizer
 
 

--- a/tests/test_downstream/test_outcomes.py
+++ b/tests/test_downstream/test_outcomes.py
@@ -68,7 +68,6 @@ class TestOutcomeHandler(unittest.TestCase):
 
         # Initialize the OutcomeHandler instance
         self.handler = OutcomeHandler(
-            survival=True,
             end_of_time={
                 "year": 2021,
                 "month": 12,
@@ -79,7 +78,6 @@ class TestOutcomeHandler(unittest.TestCase):
             },
         )
         self.handler_wdeath = OutcomeHandler(
-            survival=False,
             end_of_time={
                 "year": 2021,
                 "month": 12,


### PR DESCRIPTION
This PR focuses on simulation of binary outcomes. In addition improve configuration handling, updating file paths,The most 

### Simulation :
* [`ehr2vec/main/simulate_outcome_binary.py`](diffhunk://#diff-5463c32e313b386847d27656917cdd443391234e914086e97b3c07ee8e79cc23L5-R5): Added `numpy` import, renamed `CONFIG_NAME` to `DEFAULT_CONFIG_NAME`, and introduced a `simulate_outcome` helper function. Modified the main function to generate counterfactual outcomes and save them to a new CSV file. [[1]](diffhunk://#diff-5463c32e313b386847d27656917cdd443391234e914086e97b3c07ee8e79cc23L5-R5) [[2]](diffhunk://#diff-5463c32e313b386847d27656917cdd443391234e914086e97b3c07ee8e79cc23L18-R21) [[3]](diffhunk://#diff-5463c32e313b386847d27656917cdd443391234e914086e97b3c07ee8e79cc23L36-R39) [[4]](diffhunk://#diff-5463c32e313b386847d27656917cdd443391234e914086e97b3c07ee8e79cc23R49-R51) [[5]](diffhunk://#diff-5463c32e313b386847d27656917cdd443391234e914086e97b3c07ee8e79cc23R65-R66)


### Configuration Handling Improvements:
* [`ehr2vec/common/setup.py`](diffhunk://#diff-fbc589284dfb0344d780a0ec58fdf71670803974f71f198361d41f3736f975d2L22-R22): Added a `help` parameter to the `--config_path` argument and ensured the config path ends with `.yaml`. [[1]](diffhunk://#diff-fbc589284dfb0344d780a0ec58fdf71670803974f71f198361d41f3736f975d2L22-R22) [[2]](diffhunk://#diff-fbc589284dfb0344d780a0ec58fdf71670803974f71f198361d41f3736f975d2R34-R36)

### Path Updates:
* [`ehr2vec/configs/finetune/finetune_simvastatin.yaml`](diffhunk://#diff-0b3f0c0c62697839117ad0b134271dbca612693a839f64e90dbc59702b27b4caL3-R7): Updated paths for pretraining model and outcome files to use example directories.
* [`ehr2vec/configs/outcome/outcomes_simvastatin.yaml`](diffhunk://#diff-7392f461d04e9c628dfe3e3ef751f418af6018cd87a654cecc15e8210679e6c6L3-R7): Changed `features_dir` and `data_dir` to use example directories and updated the `match` value. [[1]](diffhunk://#diff-7392f461d04e9c628dfe3e3ef751f418af6018cd87a654cecc15e8210679e6c6L3-R7) [[2]](diffhunk://#diff-7392f461d04e9c628dfe3e3ef751f418af6018cd87a654cecc15e8210679e6c6L16-R16)
* [`ehr2vec/configs/simulate_binary_outcome.yaml`](diffhunk://#diff-0e4752969db9cfa83bece54933dbb3ce35ebe3a8bceeea6105f936d257d3f9ddL3-R5): Updated model path and output path to use example directories.

