### PR TITLE
Add codes during tokenization which do not appear int the PT set.

### DIFF
--- a/ehr2vec/configs/create_data_example.yaml
+++ b/ehr2vec/configs/create_data_example.yaml
@@ -28,6 +28,8 @@ tokenizer:
   cls_token: true
   padding: false
   truncation: null
+  additional_codes:
+    - DT148XXX
   # cutoffs:
    # D: 3 # diagnosis
    # M: 4 # medication

--- a/ehr2vec/data/tokenizer.py
+++ b/ehr2vec/data/tokenizer.py
@@ -23,6 +23,7 @@ class EHRTokenizer:
         self.truncation = config.get("truncation", None)
         self.padding = config.get("padding", False)
         self.cutoffs = config.get("cutoffs", None)
+        self.additional_codes = config.get("additional_codes", None)
 
     def __call__(self, features: dict, padding=None, truncation=None) -> BatchEncoding:
         padding = self.padding if padding is None else padding
@@ -71,6 +72,10 @@ class EHRTokenizer:
             for concept in concepts:
                 if concept not in self.vocabulary:
                     self.vocabulary[concept] = len(self.vocabulary)
+            if self.additional_codes:
+                for code in self.additional_codes:
+                    if code not in self.vocabulary:
+                        self.vocabulary[code] = len(self.vocabulary)
 
             encoded_sequence = [
                 self.vocabulary.get(concept, self.vocabulary["[UNK]"])


### PR DESCRIPTION
This is useful if we exclude exposed patients from pretraining to not memorize the patients, but still need the codes of exposure. Otherwise we will have UNK codes for exposure when predicting outcome.