### PR TITLE
Exposed as controls

### DIFF
--- a/ehr2vec/common/loader.py
+++ b/ehr2vec/common/loader.py
@@ -112,7 +112,9 @@ class FeaturesLoader:
 
         return torch.load(vocabulary_file_path)
 
-    def load_outcomes_and_exposures(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    def load_outcomes_and_exposures(
+        self,
+    ) -> Tuple[pd.DataFrame, pd.DataFrame, Union[pd.DataFrame, None]]:
         """
         Load outcomes and censoring timestamps from file.
         If no censoring timestamps provided, use outcomes as censoring timestamps.
@@ -126,7 +128,11 @@ class FeaturesLoader:
             return outcomes, outcomes.copy(deep=True)
         logger.info(f"Load exposure timestamps from {self.path_cfg.exposure}")
         exposures = pd.read_csv(self.path_cfg.exposure)
-        return outcomes, exposures
+        if self.path_cfg.get("control", None):
+            logger.info(f"Load control timestamps from {self.path_cfg.control}")
+            control_exposures = pd.read_csv(self.path_cfg.control)
+            return outcomes, exposures, control_exposures
+        return outcomes, exposures, None
 
     def load_finetune_data(self, path: str = None, mode: str = None) -> Data:
         """Load features for finetuning"""

--- a/ehr2vec/configs/example_configs/03_outcomes.yaml
+++ b/ehr2vec/configs/example_configs/03_outcomes.yaml
@@ -6,7 +6,6 @@ features_dir: outputs/example_features
 loader:
   data_dir: example_data/synthea500
   concepts: [
-    diagnose,
     medication
   ]
   batch_size: 50
@@ -17,6 +16,11 @@ outcomes:
     match: [['DT148XX']]
     exclude: ['DT148XX2']
     match_how: contains
+    case_sensitive: true
+  EXAMPLE_CONTROL:
+    type: [CONCEPT]
+    match: [['M']]  
+    match_how: startswith
     case_sensitive: true
   EXAMPLE_CENSOR:
     type: [CONCEPT]

--- a/ehr2vec/configs/example_configs/03_outcomes.yaml
+++ b/ehr2vec/configs/example_configs/03_outcomes.yaml
@@ -6,7 +6,8 @@ features_dir: outputs/example_features
 loader:
   data_dir: example_data/synthea500
   concepts: [
-    medication
+    medication,
+    diagnose
   ]
   batch_size: 50
   chunksize: 300

--- a/ehr2vec/configs/example_configs/03_outcomes.yaml
+++ b/ehr2vec/configs/example_configs/03_outcomes.yaml
@@ -20,7 +20,7 @@ outcomes:
     case_sensitive: true
   EXAMPLE_CONTROL:
     type: [CONCEPT]
-    match: [['M']]  
+    match: [['M3']]  
     match_how: startswith
     case_sensitive: true
   EXAMPLE_CENSOR:

--- a/ehr2vec/configs/example_configs/04_finetune.yaml
+++ b/ehr2vec/configs/example_configs/04_finetune.yaml
@@ -5,6 +5,7 @@ paths:
   # checkpoint_epoch: 1
   outcome: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_OUTCOME.csv"
   exposure: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CENSOR.csv"
+  control: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CONTROL.csv"
   # output_path: "outputs/finetuning"
   run_name: "test"
   # tokenized_dir:"tokenized"

--- a/ehr2vec/configs/example_configs/04_finetune.yaml
+++ b/ehr2vec/configs/example_configs/04_finetune.yaml
@@ -5,7 +5,7 @@ paths:
   # checkpoint_epoch: 1
   outcome: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_OUTCOME.csv"
   exposure: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CENSOR.csv"
-  control: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CONTROL.csv"
+  # control: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CONTROL.csv"
   # output_path: "outputs/finetuning"
   run_name: "test"
   # tokenized_dir:"tokenized"

--- a/ehr2vec/configs/example_configs/04_finetune.yaml
+++ b/ehr2vec/configs/example_configs/04_finetune.yaml
@@ -5,7 +5,7 @@ paths:
   # checkpoint_epoch: 1
   outcome: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_OUTCOME.csv"
   exposure: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CENSOR.csv"
-  # control: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CONTROL.csv"
+  control: "outputs/example_features/outcomes/EXAMPLE_OUTCOME/EXAMPLE_CONTROL.csv"
   # output_path: "outputs/finetuning"
   run_name: "test"
   # tokenized_dir:"tokenized"

--- a/ehr2vec/data/concept_loader.py
+++ b/ehr2vec/data/concept_loader.py
@@ -46,15 +46,22 @@ class ConceptLoader:
         assert os.path.exists(data_dir), f"Data directory {data_dir} does not exist"
 
     def _verify_paths(self, concepts) -> None:
-        assert len(self.concepts_paths) == len(
-            concepts
-        ), f"Found {len(self.concepts_paths)} concept files, expected {len(concepts)}"
-        assert all(
-            [
-                os.path.splitext(path)[1] in [".csv", ".parquet"]
-                for path in self.concepts_paths
-            ]
-        ), "Concept files must be either .csv or .parquet"
+        """Verify that the concepts paths exist and are valid"""
+        found_concepts = set(
+            os.path.basename(path).split(".")[1] for path in self.concepts_paths
+        )
+
+        if found_concepts != set(concepts):
+            missing_concepts = set(concepts) - found_concepts
+            raise FileNotFoundError(
+                f"Could not find files for the following concepts: {missing_concepts}"
+            )
+
+        for path in self.concepts_paths:
+            _, file_ext = os.path.splitext(path)
+            if file_ext not in [".csv", ".parquet"]:
+                raise ValueError(f"File {path} is not a csv or parquet file")
+
         assert (
             len(self.patients_info_path) == 1
         ), f"Found {len(self.patients_info_path)} patients info files, expected 1"

--- a/ehr2vec/data/prepare_data.py
+++ b/ehr2vec/data/prepare_data.py
@@ -118,7 +118,9 @@ class DatasetPreparer:
                 )
 
             # 3. Loading and processing outcomes
-            outcome_dates, exposure_dates = self.loader.load_outcomes_and_exposures()
+            outcome_dates, exposure_dates, control_exposure_dates = (
+                self.loader.load_outcomes_and_exposures()
+            )
             outcomehandler = OutcomeHandler(
                 index_date=self.cfg.outcome.get("index_date", None),
                 select_patient_group=data_cfg.get(
@@ -132,9 +134,10 @@ class DatasetPreparer:
                 death_is_event=self.cfg.outcome.get("death_is_event", False),
             )
             data = outcomehandler.handle(
-                data,
-                outcome_dates,
-                exposure_dates,
+                data=data,
+                outcomes=outcome_dates,
+                exposures=exposure_dates,
+                control_exposures=control_exposure_dates,
             )
             # 4. Optional: Filter code types
             if data_cfg.get("code_types"):


### PR DESCRIPTION
We can now assign exposures to controls. This allows to compare e.g. exposure with drug 1 vs exposure with drug 2.

### Main 

* Major changes to outcomehandler:
* Small change to prepare data, to pass control_exposures to outcomehandler

### Configuration updates:

* [`ehr2vec/configs/example_configs/03_outcomes.yaml`](diffhunk://#diff-c2398a7f50f3e756dbf63979aae16c804b08f783bc4d11d64c6ef0672811b54bR21-R25): Added a new `EXAMPLE_CONTROL` section to specify control exposure configurations.
* [`ehr2vec/configs/example_configs/04_finetune.yaml`](diffhunk://#diff-844da72a3d1cd61be2bed47be40d293eff5130970ef6ce07b138aae745f7854dR8): Commented out the `control` path configuration for finetuning.

### Improvements to concept path validation:

* [`ehr2vec/data/concept_loader.py`](diffhunk://#diff-f00ebeca25fd648381c3f641a479d8a0cf8b8694ffdc3d60ad3aa3fc5d3fdc0bL49-R64): Refactored `_verify_paths` to provide more detailed error messages and ensure that concept files are either `.csv` or `.parquet`.
