### PR TITLE
Fix experiments ps_noise addition

### DIFF
--- a/ehr2vec/configs/example_configs/06_estimate_effect_binary.yaml
+++ b/ehr2vec/configs/example_configs/06_estimate_effect_binary.yaml
@@ -22,5 +22,6 @@ estimator:
   methods: ["IPW"]
   effect_type: "ATE"
   n_bootstrap: 30
-
+  
+ps_noise: 0.1
 

--- a/ehr2vec/main/06_estimate_causal_effect.py
+++ b/ehr2vec/main/06_estimate_causal_effect.py
@@ -108,13 +108,10 @@ def main(config_path: str):
         logger.info(f"Sampling {cfg.num_patients} patients")
         df = df.sample(n=cfg.num_patients, replace=False)
 
-    if cfg.get("ps noise", 0) > 0:
-        logger.info(f"Adding {cfg.get('ps noise')} noise to propensity scores")
+    if cfg.get("ps_noise", 0) > 0:
+        logger.info(f"Adding {cfg.get('ps_noise')} noise to propensity scores")
         propensity_scores[PS_COL] = propensity_scores[PS_COL] * (
-            1
-            + np.random.uniform(
-                -cfg.get("ps noise"), cfg.get("ps noise"), len(propensity_scores)
-            )
+            1 + np.random.uniform(-cfg.ps_noise, cfg.ps_noise, len(propensity_scores))
         )
     stats_table = compute_treatment_outcome_table(df, TREATMENT_COL, OUTCOME_COL)
     stats_table.index.name = "Treatment"


### PR DESCRIPTION
Changes to the configuration and main script for estimating causal effects. The most important changes involve the addition of a new configuration parameter and updates to the main script to use this new parameter.

Configuration updates:

* [`ehr2vec/configs/example_configs/06_estimate_effect_binary.yaml`](diffhunk://#diff-118c10016daadc981c3ff8b0c1b7882c434afe554300b52c48372f9ea1124505R26): Added a new parameter `ps_noise` with a value of `0.1`.

Main script updates:

* [`ehr2vec/main/06_estimate_causal_effect.py`](diffhunk://#diff-b414d8712766e39959dc815fe1695e03c6f7f57fd52427f9af0fc8456745a40fL111-R114): Updated the script to use the new `ps_noise` parameter instead of the old `ps noise` parameter for adding noise to propensity scores. This includes changes to the logging and the calculation of propensity scores.